### PR TITLE
infra: add name to Cognito's User Pool to allow one pool per stage

### DIFF
--- a/resources/cognito/CognitoUserPool.yml
+++ b/resources/cognito/CognitoUserPool.yml
@@ -1,6 +1,7 @@
 CognitoUserPool:
   Type: AWS::Cognito::UserPool
   Properties:
+    UserPoolName: ${self:custom.stage}-twitter-user-pool
     AutoVerifiedAttributes:
       - email
     Policies:


### PR DESCRIPTION
Add property `UserPoolName` to make it easier to identify the user pool in the Cognito UI. Also, the stage name is added to the Pool's name, allowing a different user pool per deployment stage.