### PR TITLE
Develop/log retention policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8176,6 +8176,12 @@
         "type": "^2.0.0"
       }
     },
+    "nco": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nco/-/nco-1.0.1.tgz",
+      "integrity": "sha1-ho3kI7T0X4wFVV8cyyiqeIvgbFI=",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -10234,6 +10240,24 @@
             "compress-commons": "^2.1.1",
             "readable-stream": "^3.4.0"
           }
+        }
+      }
+    },
+    "serverless-plugin-log-retention": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-log-retention/-/serverless-plugin-log-retention-2.0.0.tgz",
+      "integrity": "sha512-TXKMfLdVxhamyaDbqr+gwjIeiqSnDw3z+bZQy0W2ctRpcedUY8hg58wwMZqAFyMS3QekHT9srCe4Qv7lfPwkGw==",
+      "dev": true,
+      "requires": {
+        "nco": "1.0.1",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "serverless-export-env": "^1.4.0",
     "serverless-iam-roles-per-function": "^2.0.2",
     "serverless-layers": "^2.3.3",
+    "serverless-plugin-log-retention": "^2.0.0",
     "ws": "^7.4.4"
   },
   "dependencies": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -6,6 +6,7 @@ plugins:
   - serverless-iam-roles-per-function
   - serverless-export-env
   - serverless-layers
+  - serverless-plugin-log-retention
 
 provider:
   name: aws
@@ -27,6 +28,7 @@ custom:
     - ${file(serverless.appsync-api.yml)}
   serverless-layers:
     layersDeploymentBucket: ${ssm:/twitterappsync/${self:custom.stage}/layer-deployment-bucket}
+  logRetentionInDays: 1
 
 functions:
   confirmUserSignup:


### PR DESCRIPTION
Configure a 1-day log retention policy on AWS CloudWatch with the plugin serverless-plugin-log-retention.