### PR TITLE
feat: configure per-resolver cache instance

### DIFF
--- a/serverless.appsync-api.yml
+++ b/serverless.appsync-api.yml
@@ -1,5 +1,6 @@
 name: twitter
 schema: schema.api.graphql
+caching: ${self:custom.appSyncCaching.${self:custom.stage}, self:custom.appSyncCaching.default}
 authenticationType: AMAZON_COGNITO_USER_POOLS
 userPoolConfig:
   awsRegion: eu-west-1
@@ -21,6 +22,10 @@ mappingTemplates:
   - type: Query
     field: getProfile
     dataSource: usersTable
+    caching:
+      keys:
+        - $context.arguments.screenName
+      ttl: 300 # 5 minutes in seconds
   - type: Query
     field: getImageUploadUrl
     dataSource: getImageUploadUrlFunction
@@ -131,16 +136,31 @@ mappingTemplates:
   - type: Tweet
     field: profile
     dataSource: usersTable
+    caching:
+      keys:
+        - $context.identity.username
+        - $context.source.creator
+      ttl: 300 # 5 minutes in seconds
   - type: Retweet
     field: profile
     dataSource: usersTable
     request: Tweet.profile.request.vtl
     response: Tweet.profile.response.vtl
+    caching:
+      keys:
+        - $context.identity.username
+        - $context.source.creator
+      ttl: 300 # 5 minutes in seconds
   - type: Reply
     field: profile
     dataSource: usersTable
     request: Tweet.profile.request.vtl
     response: Tweet.profile.response.vtl
+    caching:
+      keys:
+        - $context.identity.username
+        - $context.source.creator
+      ttl: 300 # 5 minutes in seconds
   - type: Tweet
     field: liked
     dataSource: likesTable
@@ -166,6 +186,11 @@ mappingTemplates:
   - type: Reply
     field: inReplyToUsers
     dataSource: usersTable
+    caching:
+      keys:
+        - $context.identity.username
+        - $context.source.inReplyToUserIds
+      ttl: 300 # 5 minutes in seconds
   - type: UnhydratedTweetsPage
     field: tweets
     dataSource: tweetsTable

--- a/serverless.yml
+++ b/serverless.yml
@@ -29,6 +29,12 @@ custom:
   serverless-layers:
     layersDeploymentBucket: ${ssm:/twitterappsync/${self:custom.stage}/layer-deployment-bucket}
   logRetentionInDays: 1
+  appSyncCaching:
+    default:
+    prod:
+      behavior: PER_RESOLVER_CACHING
+      ttl: 3600
+      type: T2_LARGE
 
 functions:
   confirmUserSignup:


### PR DESCRIPTION
Configured a managed cache layer to the AppSync API. In this specific configuration, it'll add a T2_LARGE instance to the production environment, and no instances at all to other stages in order to reduce costs.

To add a caching layer per stage, simply add a new stage under `custom.appSyncCaching` on the `serverless.yml` file.