### PR TITLE
fix: update incorrect caching type name from T2_LARGE to LARGE

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -31,10 +31,10 @@ custom:
   logRetentionInDays: 1
   appSyncCaching:
     default:
-    prod:
-      behavior: PER_RESOLVER_CACHING
-      ttl: 3600
-      type: T2_LARGE
+    # prod:
+    #   behavior: PER_RESOLVER_CACHING
+    #   ttl: 3600
+    #   type: LARGE
 
 functions:
   confirmUserSignup:


### PR DESCRIPTION
Update the caching type from **T2_LARGE** to **LARGE**, which is the correct one.

Also, I commented on the appsyncCaching.prod because nowadays the workflow `prod.yml` is triggered when new pull requests are merged. That means this workflow would actually set up a large instance on AWS.