### PR TITLE
feat: add BatchInvoke to Lambda GraphQL resolver

### DIFF
--- a/functions/get-tweet-creator.js
+++ b/functions/get-tweet-creator.js
@@ -1,0 +1,38 @@
+const _ = require('lodash');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
+const DocumentClient = new DynamoDB.DocumentClient();
+
+const { USERS_TABLE } = process.env;
+
+module.exports.handler = async (payloads) => {
+  const { caller, selection } = payloads[0];
+  const userIds = payloads.map(x => x.userId);
+
+  if (selection.length === 1 && selection[0] === 'id') {
+    return userIds.map(id => ({
+      id,
+      __typename: id === caller ? 'MyProfile' : 'OtherProfile',
+    }));
+  }
+
+  const uniqueUserIds = _.uniq(userIds);
+
+  const response = await DocumentClient.batchGet({
+    RequestItems: {
+      [USERS_TABLE]: {
+        Keys: uniqueUserIds.map(x => ({ id: x })),
+      },
+    },
+  }).promise();
+
+  const users = response.Responses[USERS_TABLE];
+  users.forEach(user => {
+    if (user.id === caller) {
+      user.__typename = 'MyProfile'
+    } else {
+      user.__typename = 'OtherProfile'
+    }
+  });
+
+  return userIds.map(id => _.find(users, { id }));
+};

--- a/mapping-templates/Tweet.profile.batchInvoke.request.vtl
+++ b/mapping-templates/Tweet.profile.batchInvoke.request.vtl
@@ -1,0 +1,9 @@
+{
+  "version": "2018-05-29",
+  "operation": "BatchInvoke",
+  "payload": {
+    "userId": $utils.toJson($context.source.creator),
+    "caller": $utils.toJson($context.identity.username),
+    "selection": $utils.toJson($context.info.selectionSetList)
+  }
+}

--- a/serverless.appsync-api.yml
+++ b/serverless.appsync-api.yml
@@ -135,7 +135,9 @@ mappingTemplates:
   # NESTED FIELDS
   - type: Tweet
     field: profile
-    dataSource: usersTable
+    dataSource: getTweetCreatorFunction
+    request: Tweet.profile.batchInvoke.request.vtl
+    response: false # because it is a Lambda resolver
     caching:
       keys:
         - $context.identity.username
@@ -143,9 +145,9 @@ mappingTemplates:
       ttl: 300 # 5 minutes in seconds
   - type: Retweet
     field: profile
-    dataSource: usersTable
-    request: Tweet.profile.request.vtl
-    response: Tweet.profile.response.vtl
+    dataSource: getTweetCreatorFunction
+    request: Tweet.profile.batchInvoke.request.vtl
+    response: false # because it is a Lambda resolver
     caching:
       keys:
         - $context.identity.username
@@ -153,9 +155,9 @@ mappingTemplates:
       ttl: 300 # 5 minutes in seconds
   - type: Reply
     field: profile
-    dataSource: usersTable
-    request: Tweet.profile.request.vtl
-    response: Tweet.profile.response.vtl
+    dataSource: getTweetCreatorFunction
+    request: Tweet.profile.batchInvoke.request.vtl
+    response: false # because it is a Lambda resolver
     caching:
       keys:
         - $context.identity.username
@@ -344,6 +346,10 @@ dataSources:
     name: sendDirectMessageFunction
     config:
       functionName: sendDirectMessage
+  - type: AWS_LAMBDA
+    name: getTweetCreatorFunction
+    config:
+      functionName: getTweetCreator
 
 substitutions:
   TweetsTable: !Ref TweetsTable

--- a/serverless.yml
+++ b/serverless.yml
@@ -296,6 +296,15 @@ functions:
         Action: dynamodb:UpdateItem
         Resource: !GetAtt ConversationsTable.Arn
 
+  getTweetCreator:
+    handler: functions/get-tweet-creator.handler
+    environment:
+      USERS_TABLE: !Ref UsersTable
+    iamRoleStatements:
+      - Effect: Allow
+        Action: dynamodb:BatchGetItem
+        Resource: !GetAtt UsersTable.Arn
+
 resources:
   Resources:
     UsersTable: ${file(resources/dynamodb/UsersTable.yml):UsersTable}


### PR DESCRIPTION
Added a Lambda resolver to get the Tweet creator's profile through a BatchInvoke operation, in order to reduce the number of Lambda invocations.