### PR TITLE
feat: report individual errors from BatchInvoke request that gets the…

### DIFF
--- a/functions/get-tweet-creator.js
+++ b/functions/get-tweet-creator.js
@@ -1,17 +1,17 @@
-const _ = require('lodash');
-const DynamoDB = require('aws-sdk/clients/dynamodb');
+const _ = require("lodash");
+const DynamoDB = require("aws-sdk/clients/dynamodb");
 const DocumentClient = new DynamoDB.DocumentClient();
 
 const { USERS_TABLE } = process.env;
 
 module.exports.handler = async (payloads) => {
   const { caller, selection } = payloads[0];
-  const userIds = payloads.map(x => x.userId);
+  const userIds = payloads.map((x) => x.userId);
 
-  if (selection.length === 1 && selection[0] === 'id') {
-    return userIds.map(id => ({
+  if (selection.length === 1 && selection[0] === "id") {
+    return userIds.map((id) => ({
       id,
-      __typename: id === caller ? 'MyProfile' : 'OtherProfile',
+      __typename: id === caller ? "MyProfile" : "OtherProfile",
     }));
   }
 
@@ -20,19 +20,27 @@ module.exports.handler = async (payloads) => {
   const response = await DocumentClient.batchGet({
     RequestItems: {
       [USERS_TABLE]: {
-        Keys: uniqueUserIds.map(x => ({ id: x })),
+        Keys: uniqueUserIds.map((x) => ({ id: x })),
       },
     },
   }).promise();
 
   const users = response.Responses[USERS_TABLE];
-  users.forEach(user => {
+  users.forEach((user) => {
     if (user.id === caller) {
-      user.__typename = 'MyProfile'
+      user.__typename = "MyProfile";
     } else {
-      user.__typename = 'OtherProfile'
+      user.__typename = "OtherProfile";
     }
   });
 
-  return userIds.map(id => _.find(users, { id }));
+  return userIds.map((id) => {
+    const user = _.find(users, { id });
+
+    if (user) {
+      return { data: user };
+    } else {
+      return { errorType: 'UserNotFound', errorMessage: 'User is not found.' };
+    }
+  });
 };

--- a/mapping-templates/Tweet.profile.batchInvoke.response.vtl
+++ b/mapping-templates/Tweet.profile.batchInvoke.response.vtl
@@ -1,0 +1,5 @@
+#if (!$util.isNull($context.result) && !$util.isNull($context.result.errorMessage))
+  $util.error($context.result.errorMessage, $context.result.errorType)
+#else
+  $util.toJson($context.result.data)
+#end

--- a/schema.api.graphql
+++ b/schema.api.graphql
@@ -203,13 +203,13 @@ type OtherProfile implements IProfile {
 
 interface ITweet {
   id: ID!
-  profile: IProfile!
+  profile: IProfile
   createdAt: AWSDateTime!
 }
 
 type Tweet implements ITweet {
   id: ID!
-  profile: IProfile!
+  profile: IProfile
   createdAt: AWSDateTime!
   text: String!
   replies: Int!
@@ -221,7 +221,7 @@ type Tweet implements ITweet {
 
 type Reply implements ITweet {
   id: ID!
-  profile: IProfile!
+  profile: IProfile
   createdAt: AWSDateTime!
   inReplyToTweet: ITweet!
   inReplyToUsers: [IProfile!]
@@ -235,7 +235,7 @@ type Reply implements ITweet {
 
 type Retweet implements ITweet {
   id: ID!
-  profile: IProfile!
+  profile: IProfile
   createdAt: AWSDateTime!
   retweetOf: ITweet!
 }

--- a/serverless.appsync-api.yml
+++ b/serverless.appsync-api.yml
@@ -137,7 +137,7 @@ mappingTemplates:
     field: profile
     dataSource: getTweetCreatorFunction
     request: Tweet.profile.batchInvoke.request.vtl
-    response: false # because it is a Lambda resolver
+    response: Tweet.profile.batchInvoke.response.vtl
     caching:
       keys:
         - $context.identity.username
@@ -147,7 +147,7 @@ mappingTemplates:
     field: profile
     dataSource: getTweetCreatorFunction
     request: Tweet.profile.batchInvoke.request.vtl
-    response: false # because it is a Lambda resolver
+    response: Tweet.profile.batchInvoke.response.vtl
     caching:
       keys:
         - $context.identity.username
@@ -157,7 +157,7 @@ mappingTemplates:
     field: profile
     dataSource: getTweetCreatorFunction
     request: Tweet.profile.batchInvoke.request.vtl
-    response: false # because it is a Lambda resolver
+    response: Tweet.profile.batchInvoke.response.vtl
     caching:
       keys:
         - $context.identity.username


### PR DESCRIPTION
Previously, the BatchInvoke request (`Tweet.profile.batchInvoke.request.vtl`) would return an error if the profile (aka. a tweet's creator) was not found in the database for some reason. In other words, the whole batch would fail due to an isolated error.

This Pull Request adds a feature that reports individual errors for a BatchInvoke request. For example, if for some reason we're unable to get the tweet creator for 1 of 10 tweets, the BatchInvoke request will return 9 tweets and an array with that single exception. 