### PR TITLE
infra(cognito): configure Identity Pool and IAM role

### DIFF
--- a/resources/cognito/IdentityPool.yml
+++ b/resources/cognito/IdentityPool.yml
@@ -1,0 +1,9 @@
+IdentityPool:
+  Type: AWS::Cognito::IdentityPool
+  Properties:
+    AllowUnauthenticatedIdentities: true
+    AllowClassicFlow: false
+    CognitoIdentityProviders:
+      - ClientId: !Ref WebUserPoolClient
+        ProviderName: !GetAtt CognitoUserPool.ProviderName
+        ServerSideTokenCheck: true

--- a/resources/cognito/IdentityPoolRoleMapping.yml
+++ b/resources/cognito/IdentityPoolRoleMapping.yml
@@ -1,0 +1,7 @@
+IdentityPoolRoleMapping:
+  Type: AWS::Cognito::IdentityPoolRoleAttachment
+  Properties:
+    IdentityPoolId: !Ref IdentityPool
+    Roles:
+      authenticated: !GetAtt AuthedClientRole.Arn
+      unauthenticated: !GetAtt UnauthedClientRole.Arn

--- a/resources/iam/AuthedClientRole.yml
+++ b/resources/iam/AuthedClientRole.yml
@@ -1,0 +1,25 @@
+AuthedClientRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Federated: cognito-identity.amazonaws.com
+          Action: sts:AssumeRoleWithWebIdentity
+          Condition:
+            StringEquals:
+              cognito-identity.amazonaws.com:aud: !Ref IdentityPool
+            ForAnyValue:StringLike:
+              cognito-identity.amazonaws.com:amr: authenticated
+    Policies:
+      - PolicyName: CognitoPolicy
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - firehose:PutRecord
+                - firehose:PutRecordBatch
+              Resource: !GetAtt FirehoseStream.Arn

--- a/resources/iam/UnauthedClientRole.yml
+++ b/resources/iam/UnauthedClientRole.yml
@@ -1,0 +1,25 @@
+UnauthedClientRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Federated: cognito-identity.amazonaws.com
+          Action: sts:AssumeRoleWithWebIdentity
+          Condition:
+            StringEquals:
+              cognito-identity.amazonaws.com:aud: !Ref IdentityPool
+            ForAnyValue:StringLike:
+              cognito-identity.amazonaws.com:amr: unauthenticated
+    Policies:
+      - PolicyName: CognitoPolicy
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - firehose:PutRecord
+                - firehose:PutRecordBatch
+              Resource: !GetAtt FirehoseStream.Arn

--- a/scripts/test-cognito-identity.js
+++ b/scripts/test-cognito-identity.js
@@ -1,0 +1,31 @@
+require('dotenv').config();
+const AWS = require('aws-sdk');
+
+const providerName = process.env.COGNITO_USER_POOL_PROVIDER_NAME;
+
+AWS.config.credentials = new AWS.CognitoIdentityCredentials({
+  IdentityPoolId: process.env.COGNITO_IDENTITY_POOL_ID,
+  Logins: {
+    [providerName]: '12131312',
+  },
+});
+
+AWS.config.credentials.get(() => {
+  const { accessKeyId, secretAccessKey, sessionToken } = AWS.config.credentials;
+  process.env.AWS_ACCESS_KEY_ID = accessKeyId;
+  process.env.AWS_SECRET_ACCESS_KEY = secretAccessKey;
+  process.env.AWS_SESSION_TOKEN = sessionToken;
+
+  const Firehose = new AWS.Firehose();
+  Firehose.putRecord({
+    DeliveryStreamName: process.env.FIREHOSE_STREAM_NAME,
+    Record: {
+      Data: JSON.stringify({
+        eventType: 'impression',
+        tweetId: '123',
+      }),
+    },
+  }).promise()
+  .then(() => console.log('all done'))
+  .catch(e => console.error('failed', e));
+});

--- a/serverless.yml
+++ b/serverless.yml
@@ -326,6 +326,8 @@ resources:
     CognitoUserPool: ${file(resources/cognito/CognitoUserPool.yml):CognitoUserPool}
     UserPoolInvokeConfirmUserSignupLambdaPermission: ${file(resources/cognito/UserPoolInvokeConfirmUserSignupLambdaPermission.yml):UserPoolInvokeConfirmUserSignupLambdaPermission}
     WebUserPoolClient: ${file(resources/cognito/WebUserPoolClient.yml):WebUserPoolClient}
+    IdentityPool: ${file(resources/cognito/IdentityPool.yml):IdentityPool}
+    IdentityPoolRoleMapping: ${file(resources/cognito/IdentityPoolRoleMapping.yml):IdentityPoolRoleMapping}
 
     # S3
     AssetsBucket: ${file(resources/s3/AssetsBucket.yml):AssetsBucket}
@@ -340,6 +342,8 @@ resources:
 
     # IAM
     FirehoseDeliveryIamRole: ${file(resources/iam/FirehoseDeliveryIamRole.yml):FirehoseDeliveryIamRole}
+    UnauthedClientRole: ${file(resources/iam/UnauthedClientRole.yml):UnauthedClientRole}
+    AuthedClientRole: ${file(resources/iam/AuthedClientRole.yml):AuthedClientRole}
 
   Outputs:
     AwsRegion:
@@ -351,5 +355,14 @@ resources:
     WebCognitoUserPoolClientId:
       Value: !Ref WebUserPoolClient
 
+    CognitoUserPoolProviderName:
+      Value: !GetAtt CognitoUserPool.ProviderName
+
+    CognitoIdentityPoolId:
+      Value: !Ref IdentityPool
+
     ApiUrl:
       Value: !GetAtt TwitterGraphQlApi.GraphQLUrl # Got from CloudFormation template update stack (.serverless folder)
+
+    FirehoseStreamName:
+      Value: !Ref FirehoseStream


### PR DESCRIPTION
Set up Identity Pool and AM role used to allow the client to push events to the Firehose Stream, also supporting authenticated and unauthenticated clients.