### PR TITLE
feat(api/logging): set up AppSync logging to CloudWatch Logs

### DIFF
--- a/resources/iam/AppSyncLoggingServiceRole.yml
+++ b/resources/iam/AppSyncLoggingServiceRole.yml
@@ -1,0 +1,22 @@
+AppSyncLoggingServiceRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: appsync.amazonaws.com
+          Action: sts:AssumeRole
+    Path: /service-role/
+    Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+              Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*

--- a/serverless.appsync-api.yml
+++ b/serverless.appsync-api.yml
@@ -6,6 +6,10 @@ userPoolConfig:
   awsRegion: eu-west-1
   defaultAction: ALLOW
   userPoolId: !Ref CognitoUserPool
+logConfig:
+  loggingRoleArn: !GetAtt AppSyncLoggingServiceRole.Arn
+  level: ${self:custom.appSyncLogLevel.${self:custom.stage}, self:custom.appSyncLogLevel.default}
+  excludeVerboseContent: ${self:custom.appSyncLogExcludeVerboseContent.${self:custom.stage}, self:custom.appSyncLogExcludeVerboseContent.default}
 additionalAuthenticationProviders:
   - authenticationType: AWS_IAM
 mappingTemplatesLocation: mapping-templates

--- a/serverless.yml
+++ b/serverless.yml
@@ -35,6 +35,12 @@ custom:
     #   behavior: PER_RESOLVER_CACHING
     #   ttl: 3600
     #   type: LARGE
+  appSyncLogLevel:
+    default: ALL
+    prod: ERROR
+  appSyncLogExcludeVerboseContent:
+    default: false
+    prod: true
 
 functions:
   confirmUserSignup:
@@ -344,6 +350,7 @@ resources:
     FirehoseDeliveryIamRole: ${file(resources/iam/FirehoseDeliveryIamRole.yml):FirehoseDeliveryIamRole}
     UnauthedClientRole: ${file(resources/iam/UnauthedClientRole.yml):UnauthedClientRole}
     AuthedClientRole: ${file(resources/iam/AuthedClientRole.yml):AuthedClientRole}
+    AppSyncLoggingServiceRole: ${file(resources/iam/AppSyncLoggingServiceRole.yml):AppSyncLoggingServiceRole}
 
   Outputs:
     AwsRegion:


### PR DESCRIPTION
Set up AppSync logging configuration to ship API-level logs to CloudWatch Logs.

Features:
[x] Set up log level to ERROR in the ```prod``` stage and ALL to any other stage
[x] Exclude verbose content in the ```prod``` stage and keep it in the other stages