### PR TITLE
feat: switch AppSync Log Level via cron job

### DIFF
--- a/functions/set-resolver-log-level.js
+++ b/functions/set-resolver-log-level.js
@@ -1,0 +1,20 @@
+const AppSync = require('aws-sdk/clients/appsync');
+const AppSyncClient = new AppSync();
+
+const { APPSYNC_API_ID, FIELD_LOG_LEVEL } = process.env;
+
+module.exports.handler = async () => {
+  const response = await AppSyncClient.getGraphqlApi({
+    apiId: APPSYNC_API_ID,
+  }).promise();
+
+  const api = response.graphqlApi;
+  api.logConfig.fieldLogLevel = FIELD_LOG_LEVEL;
+
+  delete api.arn;
+  delete api.uris;
+  delete api.tags;
+  delete api.wafWebAclArn;
+
+  await AppSyncClient.updateGraphqlApi(api).promise();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11490,6 +11490,12 @@
         }
       }
     },
+    "serverless-plugin-ifelse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-ifelse/-/serverless-plugin-ifelse-1.0.7.tgz",
+      "integrity": "sha512-9OzcpsKOT50dO6WsGM0AiDbsN9TjH8zg/pLVOJlDjliSulWpP6Q5ceqp5zTM3eY/aAlYTq1/UBElKby6V+vZiQ==",
+      "dev": true
+    },
     "serverless-plugin-log-retention": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/serverless-plugin-log-retention/-/serverless-plugin-log-retention-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "serverless-export-env": "^1.4.0",
     "serverless-iam-roles-per-function": "^2.0.2",
     "serverless-layers": "^2.3.3",
+    "serverless-plugin-ifelse": "^1.0.7",
     "serverless-plugin-log-retention": "^2.0.0",
     "ws": "^7.4.4"
   },

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,6 +7,7 @@ plugins:
   - serverless-export-env
   - serverless-layers
   - serverless-plugin-log-retention
+  - serverless-plugin-ifelse
 
 provider:
   name: aws
@@ -41,6 +42,11 @@ custom:
   appSyncLogExcludeVerboseContent:
     default: false
     prod: true
+  serverlessIfElse:
+    - If: '"${self:custom.stage}" == "prod"' # don't do anything
+      ElseExclude:
+        - functions.setResolverLogLevelToAll
+        - functions.setResolverLogLevelToError
 
 functions:
   confirmUserSignup:
@@ -314,6 +320,40 @@ functions:
   firehoseTransformer:
     handler: functions/firehose-transformer.handler
     timeout: 61
+
+  setResolverLogLevelToAll:
+    handler: functions/set-resolver-log-level.handler
+    events:
+      - schedule: cron(6 * * * ? *) # 6 mins past the hour every hour
+    environment:
+      APPSYNC_API_ID: !GetAtt TwitterGraphQlApi.ApiId
+      FIELD_LOG_LEVEL: ALL
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - appsync:GetGraphqlApi
+          - appsync:UpdateGraphqlApi
+        Resource: !Ref TwitterGraphQlApi
+      - Effect: Allow
+        Action: iam:PassRole
+        Resource: !GetAtt AppSyncLoggingServiceRole.Arn
+
+  setResolverLogLevelToError:
+    handler: functions/set-resolver-log-level.handler
+    events:
+      - schedule: cron(12 * * * ? *) # 6 mins past the hour every hour
+    environment:
+      APPSYNC_API_ID: !GetAtt TwitterGraphQlApi.ApiId
+      FIELD_LOG_LEVEL: ERROR
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - appsync:GetGraphqlApi
+          - appsync:UpdateGraphqlApi
+        Resource: !Ref TwitterGraphQlApi
+      - Effect: Allow
+        Action: iam:PassRole
+        Resource: !GetAtt AppSyncLoggingServiceRole.Arn
 
 resources:
   Resources:


### PR DESCRIPTION
Configured a Lambda function triggered by a cron job (EventBridge Events) that switches AppSync's log level between ALL and ERROR. This way is possible to have the full request log (logLevel: ```ALL```) 10% of the time.